### PR TITLE
Update troubleshooting.md

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -33,9 +33,10 @@ Your Button Plus is restarting all the time.
 
 * Long and/or thin wiring will cause a voltage drop over the wire
   > Put the power supply in the box behind the button plus. If the wiring does not meet the requirements for 230V,
-  > consider adding a 12v (or bigger) power supply and add a LM2596 DC-DC drop down converter behind your button plus.
+  > consider adding a 12v (or bigger) power supply and add a module with for example an LM2596 DC-DC drop down converter behind your button plus.
   
   > Increase the voltage a bit but do not go over 3.6v! (see chapter 4.2 of the [ESP32-S3 datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-s3_datasheet_en.pdf))
   
-  > Add a capacitor behind your button plus. I suggest a capacitor of at least 470µF. This will act as a little buffer 
-  > for the initial current.
+  > Add a capacitor behind your button plus. I suggest a capacitor of at least 1000µF and parallel 100nF. This will act as a little buffer 
+  > for the initial current and decouple some noise.
+  


### PR DESCRIPTION
Small change to power line.
BTW: I am not so fond of increasing the voltage to 3.6. The ESP32 is able to work stable at ower than 3.3v. Higher voltage will produce more heat, decreasing the accuracy of the internal temperature sensor.